### PR TITLE
refactor: move filters not pass a ref

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -42,7 +42,7 @@ fn exec(args: Args, output: &mut (dyn Write)) -> Result<()> {
     let resp = reqwest::blocking::get(&args.url)
         .with_context(|| format!("Failed to GET: {}", &args.url))?;
 
-    let mut headers = Headers::new(resp.headers(), &args.filter, output);
+    let mut headers = Headers::new(resp.headers(), args.filter, output);
     headers.parse()?.display(args.json, resp.status())?;
 
     Ok(())

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -7,18 +7,14 @@ use reqwest::StatusCode;
 use std::collections::BTreeMap;
 use std::io::{BufWriter, Write};
 
-pub struct Headers<'a, 'b, 'c> {
-    filters: &'b Option<String>,
+pub struct Headers<'a, 'b> {
+    filters: Option<String>,
     map: &'a HeaderMap,
-    output: &'c mut (dyn Write),
+    output: &'b mut (dyn Write),
 }
 
-impl<'a, 'b, 'c> Headers<'a, 'b, 'c> {
-    pub fn new(
-        map: &'a HeaderMap,
-        filters: &'b Option<String>,
-        output: &'c mut (dyn Write),
-    ) -> Self {
+impl<'a, 'b> Headers<'a, 'b> {
+    pub fn new(map: &'a HeaderMap, filters: Option<String>, output: &'b mut (dyn Write)) -> Self {
         Self {
             filters,
             map,
@@ -29,7 +25,7 @@ impl<'a, 'b, 'c> Headers<'a, 'b, 'c> {
     pub fn parse(&mut self) -> Result<Parsed> {
         let mut filters: Vec<regex::Regex> = Vec::new();
 
-        if let Some(f) = self.filters {
+        if let Some(f) = &self.filters {
             filters = f
                 .split(',')
                 .map(|f| Regex::new(format!("(?i){f}").as_str()).unwrap())


### PR DESCRIPTION
The purpose of this change is to avoid an extra lifetime reference. 
We don't need to worry about ownership changing as we don't use the filters after we call `Headers::new`.